### PR TITLE
Fix to build failed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM archlinux:latest AS build
 WORKDIR /build
 RUN pacman --noconfirm -Syyu git make gcc
 COPY . .
-RUN git submodule init
+RUN git submodule update --init --recursive
 
 WORKDIR /build/get-mem-size
 RUN make all


### PR DESCRIPTION
get-mem-size’s build isn’t build success, so I fixed.